### PR TITLE
update NL with forecastAmount string

### DIFF
--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -304,5 +304,9 @@
 	"moreForeCasts": {
 		"message": "Vanaf vandaag kun je gemakkelijk wijzigen hoeveel dagen je in het vooruitzicht wil zien.",
 		"description": "Detailed text of the whats new popup v1.1"
+	},
+	"forecastAmount": {
+		"message": "Dagen in vooruitzicht",
+		"description": "Description for the silder that let's user determine how many days they want to see in the weather-forecast"
 	}
 }


### PR DESCRIPTION
the forecast amount-string was missing in the Dutch translation and the original i18n-title showed in the info box under the weather settings. This should fix that.
