### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/boxes.html
+++ b/boxes.html
@@ -13,7 +13,7 @@
 					<p class="box-info__text" i18n-content="gmail_description3"></p>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="gmail__count" i18n-content="gmail_amount"></label></div>
-						<div class="col-lg-6"><input type="number" value="6" id="gmail__count" max="19" min="0"></div>
+						<div class="col-lg-6"><input type="number" value="6" id="gmail__count" max="19" min="0"/></div>
 					</div>
 				</div>
 			</div>
@@ -30,7 +30,7 @@
 					<p class="box-info__text"><strong i18n-content="clock_description"></strong></p>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="clock__twelveHours"  i18n-content="clock_12h"></label></div>
-						<div class="col-lg-6"><input type="checkbox" id="clock__twelveHours" class="cmn-toggle cmn-toggle-round"><label for="clock__twelveHours"></label></div>
+						<div class="col-lg-6"><input type="checkbox" id="clock__twelveHours" class="cmn-toggle cmn-toggle-round"/><label for="clock__twelveHours"></label></div>
 					</div>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="clock__dayBackground"  i18n-content="clock_background"></label></div>
@@ -63,19 +63,19 @@
 					<p class="box-info__text"><strong i18n-content="locationBased"></strong></p>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="weather__cool" i18n-content="weather_cool"></label></div>
-						<div class="col-lg-6"><input type="checkbox" id="weather__cool" class="cmn-toggle cmn-toggle-round"><label for="weather__cool"></label></div>
+						<div class="col-lg-6"><input type="checkbox" id="weather__cool" class="cmn-toggle cmn-toggle-round"/><label for="weather__cool"></label></div>
 					</div>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="weather__celsius" i18n-content="weather_celsius"></label></div>
-						<div class="col-lg-6"><input type="checkbox" id="weather__celsius" class="cmn-toggle cmn-toggle-round" checked><label for="weather__celsius"></label></div>
+						<div class="col-lg-6"><input type="checkbox" id="weather__celsius" class="cmn-toggle cmn-toggle-round" checked/><label for="weather__celsius"></label></div>
 					</div>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="weather__count" i18n-content="weather_amount"></label></div>
-						<div class="col-lg-6"><input type="number" value="4" id="weather__count" max="5" min="0"></div>
+						<div class="col-lg-6"><input type="number" value="4" id="weather__count" max="5" min="0"/></div>
 					</div>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="weather__geolocation" i18n-content="weather_geolocation"></label></div>
-						<div class="col-lg-6"><input type="checkbox" id="weather__geolocation" class="cmn-toggle cmn-toggle-round"><label for="weather__geolocation"></label></div>
+						<div class="col-lg-6"><input type="checkbox" id="weather__geolocation" class="cmn-toggle cmn-toggle-round"/><label for="weather__geolocation"></label></div>
 						<div class="col-lg-6"></div>
 						<div class="col-lg-6"><button id="weather__updateGeolocation" class="jfk-button" i18n-content="weather_updateGeolocation"></button></div>
 					</div>
@@ -104,11 +104,11 @@
 					<p class="box-info__text"><strong i18n-content="locationBased"></strong></p>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="news__shuffle"  i18n-content="news_shuffle" class="help" i18n-values="title:news_shuffle_help"></label></div>
-						<div class="col-lg-6"><input type="checkbox" id="news__shuffle" class="cmn-toggle cmn-toggle-round"><label for="news__shuffle"></label></div>
+						<div class="col-lg-6"><input type="checkbox" id="news__shuffle" class="cmn-toggle cmn-toggle-round"/><label for="news__shuffle"></label></div>
 					</div>
 					<div class="row box-info__options">
 						<div class="col-lg-6"><label for="news__count" i18n-content="news_amount"></label></div>
-						<div class="col-lg-6"><input type="number" value="6" id="news__count" max="29" min="0"></div>
+						<div class="col-lg-6"><input type="number" value="6" id="news__count" max="29" min="0"/></div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code, and the only changes that have been made is closing of void elements.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
